### PR TITLE
Reset admin content on initial load

### DIFF
--- a/src/initContent.ts
+++ b/src/initContent.ts
@@ -1,0 +1,17 @@
+import { clearContent } from './lib/storage';
+import { useContentStore } from './stores/contentStore';
+
+export async function initContent() {
+    // Remove any previously stored content
+    useContentStore.getState().clear();
+    await clearContent();
+    localStorage.removeItem('content-store');
+
+    try {
+        const resp = await fetch('/content.json');
+        const scenes = await resp.json();
+        useContentStore.getState().publish(scenes, 'default');
+    } catch (e) {
+        console.error('Failed to load default content', e);
+    }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
+import { initContent } from './initContent';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>
@@ -11,3 +12,5 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
         </BrowserRouter>
     </React.StrictMode>
 );
+
+initContent();


### PR DESCRIPTION
## Summary
- Clear any previously stored content and load `content.json` when the app starts
- Initialize the content store with default scenes so admin uploads cleanly overwrite

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ee58e74d48323989e6a968b8ed378