### PR TITLE
Refine UI layout and improve UX

### DIFF
--- a/src/components/Player/ChoiceList.tsx
+++ b/src/components/Player/ChoiceList.tsx
@@ -21,12 +21,12 @@ export default function ChoiceList({ scene }: Props) {
     }, [scene, choose]);
 
     return (
-        <div className="p-4 grid gap-2">
+        <div className="p-4 space-y-2 bg-white/80 backdrop-blur-sm max-h-[40vh] overflow-y-auto">
             {scene.choiceRequests.map((c, i) => (
                 <button
                     key={i}
                     onClick={() => choose(c)}
-                    className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300 text-left"
+                    className="w-full px-4 py-2 bg-gray-100 rounded hover:bg-gray-200 text-left transition focus-visible:outline-blue-500"
                 >
                     {i + 1}. {c.text}
                 </button>

--- a/src/components/Player/ProgressBar.tsx
+++ b/src/components/Player/ProgressBar.tsx
@@ -6,8 +6,11 @@ export default function ProgressBar() {
     const total = useContentStore((s) => s.scenes.length || 1);
     const pct = Math.min(100, (step / total) * 100);
     return (
-        <div className="h-1 bg-gray-300">
-            <div className="h-full bg-blue-500" style={{ width: `${pct}%` }} />
+        <div className="h-2 bg-gray-300">
+            <div
+                className="h-full bg-blue-500 transition-all"
+                style={{ width: `${pct}%` }}
+            />
         </div>
     );
 }

--- a/src/components/Player/SummaryView.tsx
+++ b/src/components/Player/SummaryView.tsx
@@ -13,8 +13,8 @@ export default function SummaryView() {
         session.startSession();
     };
     return (
-        <div className="p-4 space-y-4">
-            <h2 className="text-xl font-bold">Summary</h2>
+        <div className="p-4 space-y-4 max-w-md mx-auto">
+            <h2 className="text-xl font-bold text-center">Summary</h2>
             <ul className="space-y-2">
                 {session.path.map((p, i) => (
                     <li key={i} className="border-b pb-2">
@@ -24,15 +24,18 @@ export default function SummaryView() {
                     </li>
                 ))}
             </ul>
-            <div className="flex gap-2">
-                <button className="px-3 py-1 bg-blue-600 text-white rounded" onClick={() => exportSessionJSON(version)}>
+            <div className="flex flex-col sm:flex-row gap-2">
+                <button
+                    className="flex-1 px-3 py-1 bg-blue-600 text-white rounded"
+                    onClick={() => exportSessionJSON(version)}
+                >
                     Download JSON
                 </button>
-                <button className="px-3 py-1 bg-gray-300 rounded" onClick={copy}>
+                <button className="flex-1 px-3 py-1 bg-gray-300 rounded" onClick={copy}>
                     Copy Text
                 </button>
             </div>
-            <button className="px-3 py-1 bg-green-600 text-white rounded" onClick={restart}>
+            <button className="w-full px-3 py-1 bg-green-600 text-white rounded" onClick={restart}>
                 Restart
             </button>
         </div>

--- a/src/components/Player/Viewport.tsx
+++ b/src/components/Player/Viewport.tsx
@@ -32,12 +32,13 @@ export default function Viewport({ scene }: Props) {
     }, [scene]);
     return (
         <div
-            className="flex-1 flex flex-col justify-end bg-cover bg-center p-4 text-white"
+            className="relative flex-1 bg-cover bg-center text-white flex flex-col justify-end"
             style={{ backgroundImage: `url(${bg})` }}
         >
-            <div className="bg-black/50 p-4 rounded">
+            <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent" />
+            <div className="relative p-4 space-y-2">
                 <div className="font-semibold">{scene.speaker}</div>
-                <div className="mt-2 whitespace-pre-wrap">{scene.text}</div>
+                <div className="whitespace-pre-wrap">{scene.text}</div>
             </div>
         </div>
     );

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -2,8 +2,8 @@ import AdminUploader from '../components/AdminUploader';
 
 export default function AdminPage() {
     return (
-        <div className="p-4 space-y-4">
-            <h1 className="text-xl font-bold">Admin</h1>
+        <div className="p-4 space-y-4 max-w-md mx-auto">
+            <h1 className="text-xl font-bold text-center">Admin</h1>
             <AdminUploader />
         </div>
     );

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -2,10 +2,22 @@ import { Link } from 'react-router-dom';
 
 export default function LandingPage() {
     return (
-        <div className="flex flex-col items-center justify-center min-h-screen gap-4">
-            <h1 className="text-2xl font-bold">Narrative App</h1>
-            <Link className="px-4 py-2 bg-blue-500 text-white rounded" to="/play">Start</Link>
-            <Link className="text-sm text-gray-500" to="/admin">Admin</Link>
+        <div className="flex flex-col items-center justify-center min-h-screen gap-6 px-4 text-center">
+            <h1 className="text-3xl font-bold">Narrative App</h1>
+            <p className="text-gray-600 max-w-md">
+                Experience interactive stories crafted by you.
+            </p>
+            <div className="flex flex-col gap-2 w-full max-w-xs">
+                <Link
+                    className="w-full px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                    to="/play"
+                >
+                    Start Playing
+                </Link>
+                <Link className="text-sm text-gray-500 hover:underline" to="/admin">
+                    Admin
+                </Link>
+            </div>
         </div>
     );
 }

--- a/src/pages/PlayPage.tsx
+++ b/src/pages/PlayPage.tsx
@@ -29,7 +29,7 @@ export default function PlayPage() {
     }
 
     return (
-        <div className="flex flex-col h-screen">
+        <div className="flex flex-col h-screen bg-gray-50 text-gray-900">
             <ProgressBar />
             <Viewport scene={currentScene} />
             <ChoiceList scene={currentScene} />


### PR DESCRIPTION
## Summary
- Polish landing page with centered layout and clearer call-to-action
- Restyle player interface: thicker progress bar, gradient viewport, scrollable choice list
- Center admin and summary pages for consistent UX and readability

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689eeea9c1d8832391b397b4ee8df16e