### PR TITLE
style: elevate choice list layout

### DIFF
--- a/src/components/Player/ChoiceList.tsx
+++ b/src/components/Player/ChoiceList.tsx
@@ -21,7 +21,7 @@ export default function ChoiceList({ scene }: Props) {
     }, [scene, choose]);
 
     return (
-        <div className="p-4 space-y-2 bg-white/80 backdrop-blur-sm max-h-[40vh] overflow-y-auto">
+        <div className="p-4 mt-4 mx-4 space-y-2 bg-white/80 backdrop-blur-sm max-h-[40vh] overflow-y-auto rounded-lg shadow-lg">
             {scene.choiceRequests.map((c, i) => (
                 <button
                     key={i}

--- a/src/pages/PlayPage.tsx
+++ b/src/pages/PlayPage.tsx
@@ -29,7 +29,7 @@ export default function PlayPage() {
     }
 
     return (
-        <div className="flex flex-col h-screen bg-gray-50 text-gray-900">
+        <div className="flex flex-col h-screen bg-gray-50 text-gray-900 pb-4">
             <ProgressBar />
             <Viewport scene={currentScene} />
             <ChoiceList scene={currentScene} />


### PR DESCRIPTION
## Summary
- add bottom padding on PlayPage layout so elements aren't flush against screen edges
- style ChoiceList with margin, rounded corners, and shadow to lift it from the bottom

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f015ac0908323b6f5f40c5db39610