### PR TITLE
style: elevate landing page layout

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -2,21 +2,23 @@ import { Link } from 'react-router-dom';
 
 export default function LandingPage() {
     return (
-        <div className="flex flex-col items-center justify-center min-h-screen gap-6 px-4 text-center">
-            <h1 className="text-3xl font-bold">Narrative App</h1>
-            <p className="text-gray-600 max-w-md">
-                Experience interactive stories crafted by you.
-            </p>
-            <div className="flex flex-col gap-2 w-full max-w-xs">
-                <Link
-                    className="w-full px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-                    to="/play"
-                >
-                    Start Playing
-                </Link>
-                <Link className="text-sm text-gray-500 hover:underline" to="/admin">
-                    Admin
-                </Link>
+        <div className="flex flex-col items-center justify-start min-h-screen px-4 pt-24 text-center bg-gradient-to-b from-white to-gray-100">
+            <div className="flex flex-col items-center gap-6 w-full max-w-md">
+                <h1 className="text-4xl font-bold tracking-tight text-gray-900">Narrative App</h1>
+                <p className="text-gray-600">
+                    Experience interactive stories crafted by you.
+                </p>
+                <div className="flex flex-col gap-2 w-full max-w-xs">
+                    <Link
+                        className="w-full px-4 py-2 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700"
+                        to="/play"
+                    >
+                        Start Playing
+                    </Link>
+                    <Link className="text-sm text-gray-500 hover:underline" to="/admin">
+                        Admin
+                    </Link>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- lift landing page content closer to top for better balance
- add subtle gradient and spacing tweaks for a cleaner look

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f037ec9488323b391f2dc499c7b5e